### PR TITLE
Fix decompose

### DIFF
--- a/src/core/transform/decompose.rs
+++ b/src/core/transform/decompose.rs
@@ -35,6 +35,7 @@ pub fn decompose(
     let mut count = 0;
     let mut norm: Float = 0.0;
     loop {
+        // Compute inverse of _R_ and check for singularity
         assert!(invertible(&r));
         if let Some(r_it) = r.transpose().inverse() {
             // Compute next matrix _Rnext_ in series
@@ -53,6 +54,9 @@ pub fn decompose(
                     r_next = mm * is;
                 }
             }
+            let q = Quaternion::from(r_next);
+            let q = q.normalize();
+            r_next = q.to_matrix();
             // pbrt-r3
 
             // Compute norm of difference between _R_ and _Rnext_


### PR DESCRIPTION
This pull request includes changes to the `decompose` function in the `src/core/transform/decompose.rs` file. The changes focus on improving the matrix decomposition process by adding a check for matrix singularity and normalizing a quaternion before converting it back to a matrix.

Improvements to matrix decomposition:

* Added a comment to explain the computation of the inverse of matrix `R` and the check for singularity. (`src/core/transform/decompose.rs`)
* Added normalization of the quaternion derived from `r_next` before converting it back to a matrix. (`src/core/transform/decompose.rs`)