### PR TITLE
Fix output target of ProgressReporter

### DIFF
--- a/src/core/misc/progressreporter.rs
+++ b/src/core/misc/progressreporter.rs
@@ -6,7 +6,7 @@ pub struct ProgressReporter {
 
 impl ProgressReporter {
     pub fn new(total_work: usize, title: &str) -> Self {
-        let pb = ProgressBar::new(total_work as u64);
+        let pb = ProgressBar::with_draw_target(Some(total_work as u64), ProgressDrawTarget::stdout());
         //let template =
         //    format!("{}: ", title) + "[{wide_bar}]  ({elapsed_precise}|{eta_precise}) ";
         let template = format!("{{spinner:.bold.green}} {}: ", title)


### PR DESCRIPTION
This pull request includes a change to the `ProgressReporter` struct in `src/core/misc/progressreporter.rs` to enhance progress bar functionality. The most important change is the replacement of `ProgressBar::new` with `ProgressBar::with_draw_target` to allow specifying a custom draw target.

Enhancements to progress bar functionality:

* [`src/core/misc/progressreporter.rs`](diffhunk://#diff-94c4f9365143a42d8a3999dd5d1991b9c6eb884453771aab8db9e9b4576efcd7L9-R9): Replaced `ProgressBar::new` with `ProgressBar::with_draw_target`, enabling the use of `ProgressDrawTarget::stdout()` for more flexible progress bar rendering.