### PR TITLE
Fix dots texture

### DIFF
--- a/src/textures/dots.rs
+++ b/src/textures/dots.rs
@@ -34,7 +34,7 @@ impl<T: Copy> Texture<T> for DotsTexture<T> {
             let t_center = t_cell + max_shift * noise(s_cell + 4.5, t_cell + 9.8, 0.0);
             let dst = st - Point2f::new(s_center, t_center);
             if dst.length_squared() < radius * radius {
-                self.inside_dot.as_ref().evaluate(si);
+                return self.inside_dot.as_ref().evaluate(si);
             }
         }
         return self.outside_dot.as_ref().evaluate(si);


### PR DESCRIPTION
This pull request includes a small change to the `DotsTexture` implementation in `src/textures/dots.rs`. The change modifies the logic to immediately return the result of `self.inside_dot.as_ref().evaluate(si)` when the condition is met, instead of just evaluating the expression without returning it.