### PR TITLE
Fix Mipmap

### DIFF
--- a/src/core/texture/mipmap_cache.rs
+++ b/src/core/texture/mipmap_cache.rs
@@ -94,10 +94,7 @@ pub fn load_float_mipmap_cache(dir: &str, file_hash: &str) -> Result<MIPMap<Floa
         let mip_image_path = dir.join(format!("{}.exr", i));
         let (image, resolution) = read_cache_image(mip_image_path.to_str().unwrap())?;
         let image = convert_float_image(image, &resolution);
-        let mip_image = F32MIPMapImage::new(
-            image,
-            (resolution.x as usize, resolution.y as usize),
-        );
+        let mip_image = F32MIPMapImage::new(image, (resolution.x as usize, resolution.y as usize));
         pyramid.push(mip_image);
     }
     let mipmap = MIPMap::<Float>::make_from_pyramid(
@@ -154,10 +151,7 @@ pub fn load_spectrum_mipmap_cache(
         let mip_image_path = dir.join(format!("{}.exr", i));
         let (image, resolution) = read_cache_image(mip_image_path.to_str().unwrap())?;
         let image = convert_spectrum_image(image, &resolution);
-        let mip_image = F32MIPMapImage::new(
-            image,
-            (resolution.x as usize, resolution.y as usize),
-        );
+        let mip_image = F32MIPMapImage::new(image, (resolution.x as usize, resolution.y as usize));
         pyramid.push(mip_image);
     }
     let mipmap = MIPMap::<RGBSpectrum>::make_from_pyramid(

--- a/src/integrators/subpath/generate_subpath.rs
+++ b/src/integrators/subpath/generate_subpath.rs
@@ -211,13 +211,8 @@ pub fn generate_light_subpath(
         }
 
         // Generate first vertex on light subpath and start random walk
-        let vertex = Vertex::create_light_from_ray(
-            &light,
-            &ray,
-            &n_light,
-            &le,
-            pdf_pos * light_pdf,
-        );
+        let vertex =
+            Vertex::create_light_from_ray(&light, &ray, &n_light, &le, pdf_pos * light_pdf);
         path.push(vertex);
         if max_depth == 1 {
             return path.len();
@@ -332,8 +327,7 @@ fn mis_weight(
 
     if let Some(v) = pt.as_mut() {
         let pdf = if s > 0 {
-            qs.as_ref().unwrap()
-                .pdf(scene, qs_minus.as_ref(), v)
+            qs.as_ref().unwrap().pdf(scene, qs_minus.as_ref(), v)
         } else {
             v.pdf_light_origin(scene, pt_minus.as_ref().unwrap(), light_pdf, light_to_index)
         };
@@ -383,7 +377,9 @@ fn mis_weight(
             let prev = if (i - 1) == t - 1 {
                 pt.as_ref().unwrap_or(&camera_vertices[(i - 1) as usize])
             } else if (i - 1) == t - 2 {
-                pt_minus.as_ref().unwrap_or(&camera_vertices[(i - 1) as usize])
+                pt_minus
+                    .as_ref()
+                    .unwrap_or(&camera_vertices[(i - 1) as usize])
             } else {
                 &camera_vertices[(i - 1) as usize]
             };
@@ -440,7 +436,9 @@ fn mis_weight(
                 let prev = if (i - 1) == s - 1 {
                     qs.as_ref().unwrap_or(&light_vertices[(i - 1) as usize])
                 } else if (i - 1) == s - 2 {
-                    qs_minus.as_ref().unwrap_or(&light_vertices[(i - 1) as usize])
+                    qs_minus
+                        .as_ref()
+                        .unwrap_or(&light_vertices[(i - 1) as usize])
                 } else {
                     &light_vertices[(i - 1) as usize]
                 };
@@ -506,8 +504,7 @@ fn mis_weight_s1(
         }
         // i = t - 2
         if t - 2 > 0 {
-            let v = camera_vertices[(t - 2) as usize]
-                .pdf_fwd;
+            let v = camera_vertices[(t - 2) as usize].pdf_fwd;
             let pdf_delta = remap0(pt_minus_pdf_rev.unwrap()) / remap0(v);
             debug_assert!(pdf_delta.is_finite());
             debug_assert!(pdf_delta >= 0.0);
@@ -571,7 +568,7 @@ pub fn connect_bdpt(
 
     let mut l = Spectrum::zero();
     let mut sampled: Option<Vertex> = None;
-                            // Perform connection and write contribution to _L_
+    // Perform connection and write contribution to _L_
     if s == 0 {
         assert!(t >= 1);
         // Interpret the camera subpath as a complete path
@@ -616,17 +613,14 @@ pub fn connect_bdpt(
         // Sample a point on a light and connect it to the camera subpath
         let pt = &camera_vertices[(t - 1) as usize];
         if pt.is_connectible() {
-            let (light_num, light_pdf, _remapped) =
-                light_distr.sample_discrete(sampler.get_1d());
+            let (light_num, light_pdf, _remapped) = light_distr.sample_discrete(sampler.get_1d());
             let light = &scene.lights[light_num];
             let inter = pt.get_interaction();
-            if let Some((light_weight, wi, pdf, vis)) = light.sample_li(&inter, &sampler.get_2d())
-            {
+            if let Some((light_weight, wi, pdf, vis)) = light.sample_li(&inter, &sampler.get_2d()) {
                 if pdf > 0.0 && !light_weight.is_black() {
                     let ei = EndpointInteraction::from_light_interaction(&light, &vis.p1);
                     let sampled_beta = light_weight / (pdf * light_pdf);
-                    let mut sampled_v =
-                        Vertex::create_light_from_endpoint(&ei, &sampled_beta, 0.0);
+                    let mut sampled_v = Vertex::create_light_from_endpoint(&ei, &sampled_beta, 0.0);
                     let pdf_fwd =
                         sampled_v.pdf_light_origin(scene, pt, light_distr, light_to_index);
                     assert!(pdf_fwd >= 0.0);

--- a/src/integrators/subpath/vertex.rs
+++ b/src/integrators/subpath/vertex.rs
@@ -26,8 +26,7 @@ pub fn correct_shading_normal(
 ) -> Float {
     if mode == TransportMode::Importance {
         let num = Vector3f::abs_dot(wo, &isect.shading.n) * Vector3f::abs_dot(wi, &isect.n);
-        let denom =
-            Vector3f::abs_dot(wo, &isect.n) * Vector3f::abs_dot(wi, &isect.shading.n);
+        let denom = Vector3f::abs_dot(wo, &isect.n) * Vector3f::abs_dot(wi, &isect.shading.n);
         if denom == 0.0 {
             return 0.0;
         }
@@ -253,8 +252,9 @@ impl Vertex {
             VertexType::Surface => {
                 let si = self.interaction.as_surface().unwrap();
                 let bsdf = si.bsdf.as_ref().unwrap();
-                bsdf.num_components(BSDF_DIFFUSE | BSDF_GLOSSY | BSDF_REFLECTION | BSDF_TRANSMISSION)
-                    > 0
+                bsdf.num_components(
+                    BSDF_DIFFUSE | BSDF_GLOSSY | BSDF_REFLECTION | BSDF_TRANSMISSION,
+                ) > 0
             }
         }
     }
@@ -295,7 +295,8 @@ impl Vertex {
             VertexInteraction::EndPoint(ei) => {
                 let mut le = Spectrum::zero();
                 if ei.is_infinite_light() {
-                    let ray = RayDifferential::from(Ray::new(&self.get_p(), &-w, Float::INFINITY, 0.0));
+                    let ray =
+                        RayDifferential::from(Ray::new(&self.get_p(), &-w, Float::INFINITY, 0.0));
                     for light in scene.infinite_lights.iter() {
                         le += light.le(&ray);
                     }
@@ -363,7 +364,13 @@ impl Vertex {
         beta: &Spectrum,
         pdf: Float,
     ) -> Self {
-        let v = Vertex::new(*beta, VertexInteraction::EndPoint(ei.clone()), false, pdf, 0.0);
+        let v = Vertex::new(
+            *beta,
+            VertexInteraction::EndPoint(ei.clone()),
+            false,
+            pdf,
+            0.0,
+        );
         assert!(v.get_type() == VertexType::Light);
         v
     }
@@ -374,7 +381,13 @@ impl Vertex {
         pdf: Float,
         prev: &Vertex,
     ) -> Self {
-        let mut v = Vertex::new(*beta, VertexInteraction::Surface(si.clone()), false, 0.0, 0.0);
+        let mut v = Vertex::new(
+            *beta,
+            VertexInteraction::Surface(si.clone()),
+            false,
+            0.0,
+            0.0,
+        );
         v.pdf_fwd = prev.convert_density(pdf, &v);
         assert!(v.get_type() == VertexType::Surface);
         v
@@ -386,7 +399,13 @@ impl Vertex {
         pdf: Float,
         prev: &Vertex,
     ) -> Self {
-        let mut v = Vertex::new(*beta, VertexInteraction::Medium(mi.clone()), false, 0.0, 0.0);
+        let mut v = Vertex::new(
+            *beta,
+            VertexInteraction::Medium(mi.clone()),
+            false,
+            0.0,
+            0.0,
+        );
         v.pdf_fwd = prev.convert_density(pdf, &v);
         assert!(v.get_type() == VertexType::Medium);
         v

--- a/src/textures/imagemap.rs
+++ b/src/textures/imagemap.rs
@@ -63,7 +63,7 @@ impl Texture<Float> for ImageTexture<Float, Float> {
 impl Texture<Spectrum> for ImageTexture<RGBSpectrum, Spectrum> {
     fn evaluate(&self, si: &SurfaceInteraction) -> Spectrum {
         let (st, dstdx, dstdy) = self.mapping.map(si);
-        return Self::convert_out(&self.mipmap.lookup_delta_rgb(&st, &dstdx, &dstdy));
+        return Self::convert_out(&self.mipmap.lookup_delta(&st, &dstdx, &dstdy));
     }
 }
 


### PR DESCRIPTION
This pull request primarily refactors and improves the `MIPMap` texture filtering code and makes minor formatting and clarity improvements across the codebase. The main changes focus on encapsulating internal state, improving wrapping logic, and clarifying the interface for texture lookups, especially for trilinear and EWA filtering. Several formatting improvements were also made for consistency and readability.

**MIPMap Texture Filtering Improvements:**

* Changed `MIPMap` struct fields (`do_trilinear`, `max_anisotropy`, `swrap_mode`, `twrap_mode`) from public to private to better encapsulate internal state.
* Refactored trilinear and EWA filtering logic: split `lookup_delta` into `lookup_delta_trilinear` (for trilinear) and EWA logic, making the distinction clearer and improving maintainability. The EWA function is now commented out, indicating possible future work or deprecation.
* Enhanced `triangle` filter to use correct wrapping modes for texture coordinate access, handling all combinations of repeat and clamp modes for both axes.
* Updated EWA filtering in both `RGBSpectrum` and `Float` variants to use the correct wrapping logic for texel lookup, improving correctness for edge cases. [[1]](diffhunk://#diff-15cc2a32038985dfff9c670553d903ef2d9ad4ffd1a1acc8bd646a7e180bf742L795-R807) [[2]](diffhunk://#diff-15cc2a32038985dfff9c670553d903ef2d9ad4ffd1a1acc8bd646a7e180bf742R883-R915)

**API and Interface Adjustments:**

* Changed `lookup_delta_rgb` and `lookup_delta_float` methods to private, and added public `lookup_delta` methods that dispatch to the correct implementation, unifying the interface for users of `MIPMap`. [[1]](diffhunk://#diff-15cc2a32038985dfff9c670553d903ef2d9ad4ffd1a1acc8bd646a7e180bf742L810-R821) [[2]](diffhunk://#diff-15cc2a32038985dfff9c670553d903ef2d9ad4ffd1a1acc8bd646a7e180bf742R853-R856) [[3]](diffhunk://#diff-15cc2a32038985dfff9c670553d903ef2d9ad4ffd1a1acc8bd646a7e180bf742R947-R950)

**Formatting and Readability:**

* Reformatted several code blocks for clarity, including closure formatting, variable assignments, and function calls in `mipmap_cache.rs` and `sppm.rs`. [[1]](diffhunk://#diff-c4e94e214340a858a6559ec9a10acabaa13965345eac1ce1402126afa9224875L97-R97) [[2]](diffhunk://#diff-c4e94e214340a858a6559ec9a10acabaa13965345eac1ce1402126afa9224875L157-R154) [[3]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL253-R256) [[4]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL265-R276) [[5]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL328-R332) [[6]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL341-R345) [[7]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL383-R388) [[8]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL425-R433) [[9]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL492-R499) [[10]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL567-R573) [[11]](diffhunk://#diff-59089573fa908ac83dd5aa9441ee3b2bb7787257726259ac944a6fab8b0332ddL616-R621)