### PR TITLE
Fix degenerate BVH splits

### DIFF
--- a/src/accelerators/bvh/build/node.rs
+++ b/src/accelerators/bvh/build/node.rs
@@ -53,26 +53,25 @@ pub fn recursive_build(
             c_bounds = c_bounds.union_p(&p);
         }
         let dim = c_bounds.maximum_extent();
+        if c_bounds.min[dim] == c_bounds.max[dim] {
+            let offset = ordered_indices.len();
+            for i in start..end {
+                ordered_indices.push(primitive_info[i].primitive_number);
+            }
+            return Arc::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
+        }
         match split_method {
             SplitMethod::Middle => {
                 //let mid = (start + end) / 2;
-                if c_bounds.min[dim] == c_bounds.max[dim] {
-                    let offset = ordered_indices.len();
-                    for i in start..end {
-                        ordered_indices.push(primitive_info[i].primitive_number);
-                    }
-                    return Arc::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
-                } else {
-                    let p_mid = (c_bounds.min[dim] + c_bounds.max[dim]) / 2.0;
-                    return split_middle(
-                        dim,
-                        p_mid,
-                        primitive_info,
-                        ordered_indices,
-                        max_prims_in_node,
-                        split_method,
-                    );
-                }
+                let p_mid = (c_bounds.min[dim] + c_bounds.max[dim]) / 2.0;
+                return split_middle(
+                    dim,
+                    p_mid,
+                    primitive_info,
+                    ordered_indices,
+                    max_prims_in_node,
+                    split_method,
+                );
             }
             SplitMethod::EqualCounts => {
                 return split_equal_counts(

--- a/src/accelerators/bvh/build/sah.rs
+++ b/src/accelerators/bvh/build/sah.rs
@@ -1,3 +1,4 @@
+use super::equal_counts::*;
 use super::node::*;
 use super::types::*;
 use crate::core::base::*;
@@ -131,6 +132,15 @@ pub fn split_sah(
                         .max(0) as usize;
                     b <= min_cost_split_bucket
                 });
+            if left.is_empty() || right.is_empty() {
+                return split_equal_counts(
+                    dim,
+                    primitive_info,
+                    ordered_indices,
+                    max_prims_in_node,
+                    split_method,
+                );
+            }
             let c0 = Some(recursive_build(
                 &mut left,
                 ordered_indices,


### PR DESCRIPTION
This pull request refines the BVH (Bounding Volume Hierarchy) construction logic, particularly around node splitting strategies. The main improvement ensures that if the SAH (Surface Area Heuristic) split would result in an empty partition, the algorithm gracefully falls back to an equal counts split, preventing degenerate cases and improving robustness.

**BVH Construction Improvements:**

* In `split_sah`, added a check to detect when a SAH split would produce an empty left or right partition, and fall back to `split_equal_counts` in that case to avoid degenerate BVH nodes.
* Imported the `equal_counts` module in `sah.rs` to enable the fallback logic.

**Code Structure and Logic Adjustments:**

* Refactored the order of checks and match arms in `recursive_build` to ensure the degenerate case (where all centroids are equal along the chosen dimension) is handled before attempting any split, improving clarity and correctness.
* Cleaned up match arm formatting and removed an unnecessary closing brace for better code readability in `recursive_build`.