### PR TITLE
Release/v3.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r3"
-version = "3.1.9"
+version = "3.2.0"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r3"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r3"
-version = "3.1.8"
+version = "3.1.9"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r3"

--- a/src/accelerators/bvh/build/node.rs
+++ b/src/accelerators/bvh/build/node.rs
@@ -53,26 +53,25 @@ pub fn recursive_build(
             c_bounds = c_bounds.union_p(&p);
         }
         let dim = c_bounds.maximum_extent();
+        if c_bounds.min[dim] == c_bounds.max[dim] {
+            let offset = ordered_indices.len();
+            for i in start..end {
+                ordered_indices.push(primitive_info[i].primitive_number);
+            }
+            return Arc::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
+        }
         match split_method {
             SplitMethod::Middle => {
                 //let mid = (start + end) / 2;
-                if c_bounds.min[dim] == c_bounds.max[dim] {
-                    let offset = ordered_indices.len();
-                    for i in start..end {
-                        ordered_indices.push(primitive_info[i].primitive_number);
-                    }
-                    return Arc::new(BVHBuildNode::init_leaf(offset, n_primitives, &bounds));
-                } else {
-                    let p_mid = (c_bounds.min[dim] + c_bounds.max[dim]) / 2.0;
-                    return split_middle(
-                        dim,
-                        p_mid,
-                        primitive_info,
-                        ordered_indices,
-                        max_prims_in_node,
-                        split_method,
-                    );
-                }
+                let p_mid = (c_bounds.min[dim] + c_bounds.max[dim]) / 2.0;
+                return split_middle(
+                    dim,
+                    p_mid,
+                    primitive_info,
+                    ordered_indices,
+                    max_prims_in_node,
+                    split_method,
+                );
             }
             SplitMethod::EqualCounts => {
                 return split_equal_counts(

--- a/src/accelerators/bvh/build/sah.rs
+++ b/src/accelerators/bvh/build/sah.rs
@@ -1,3 +1,4 @@
+use super::equal_counts::*;
 use super::node::*;
 use super::types::*;
 use crate::core::base::*;
@@ -131,6 +132,15 @@ pub fn split_sah(
                         .max(0) as usize;
                     b <= min_cost_split_bucket
                 });
+            if left.is_empty() || right.is_empty() {
+                return split_equal_counts(
+                    dim,
+                    primitive_info,
+                    ordered_indices,
+                    max_prims_in_node,
+                    split_method,
+                );
+            }
             let c0 = Some(recursive_build(
                 &mut left,
                 ordered_indices,

--- a/src/bin/pbrt.rs
+++ b/src/bin/pbrt.rs
@@ -300,7 +300,7 @@ fn render_scene(input_path: &Path, opts: &CommandOptions) -> i32 {
                         let integrator = integrator.as_ref().read().unwrap();
                         let camera = integrator.get_camera();
                         let film = camera.as_ref().get_film();
-                        let mut f = film.as_ref().write().unwrap();
+                        let f = film.as_ref().read().unwrap();
                         f.add_display(&display);
                     }
                     Err(e) => {
@@ -316,7 +316,7 @@ fn render_scene(input_path: &Path, opts: &CommandOptions) -> i32 {
                 let integrator = integrator.as_ref().read().unwrap();
                 let camera = integrator.get_camera();
                 let film = camera.as_ref().get_film();
-                let mut f = film.as_ref().write().unwrap();
+                let f = film.as_ref().read().unwrap();
                 f.add_display(&display);
             }
 

--- a/src/core/display/display.rs
+++ b/src/core/display/display.rs
@@ -8,7 +8,7 @@ pub struct DisplayTile {
     pub buffer: Vec<f32>,
 }
 
-pub trait Display: Sync {
+pub trait Display: Sync + Send {
     fn start(
         &mut self,
         title: &str,

--- a/src/core/film/film.rs
+++ b/src/core/film/film.rs
@@ -46,7 +46,7 @@ pub struct Film {
     pub filter: Arc<dyn Filter>,
     pub filename: String,
     pub cropped_pixel_bounds: Bounds2i,
-    pub display: MutipleDisplay,
+    display: Mutex<MutipleDisplay>,
 
     pixels: Mutex<Vec<Pixel>>,
 
@@ -150,7 +150,7 @@ impl Film {
             filter: Arc::clone(filter),
             filename: String::from(filename),
             cropped_pixel_bounds,
-            display: MutipleDisplay::new(),
+            display: Mutex::new(MutipleDisplay::new()),
 
             pixels: Mutex::new(pixels),
 
@@ -216,7 +216,7 @@ impl Film {
         )
     }
 
-    pub fn merge_film_tile(&mut self, tile: &FilmTile) {
+    pub fn merge_film_tile(&self, tile: &FilmTile) {
         let _p = ProfilePhase::new(Prof::MergeFilmTile);
 
         let bounds = tile.get_pixel_bounds();
@@ -240,7 +240,7 @@ impl Film {
         }
     }
 
-    pub fn merge_splats(&mut self, splat_scale: Float) {
+    pub fn merge_splats(&self, splat_scale: Float) {
         for tile in self.splat_tiles.iter() {
             let mut tile = tile.write().unwrap();
             if !tile.dirty {
@@ -275,12 +275,16 @@ impl Film {
         }
     }
 
-    pub fn update_display(&mut self, bounds: &Bounds2i) {
+    pub fn update_display(&self, bounds: &Bounds2i) {
         self.update_display_scale(bounds, 1.0);
     }
 
-    pub fn update_display_scale(&mut self, bounds: &Bounds2i, scale: Float) {
-        if self.display.is_empty() {
+    pub fn update_display_scale(&self, bounds: &Bounds2i, scale: Float) {
+        let has_display = {
+            let display = self.display.lock().unwrap();
+            !display.is_empty()
+        };
+        if !has_display {
             return;
         }
 
@@ -341,13 +345,14 @@ impl Film {
                 height: theight,
                 buffer,
             };
-            self.display.update(&display_tile).unwrap_or_else(|e| {
+            let mut display = self.display.lock().unwrap();
+            display.update(&display_tile).unwrap_or_else(|e| {
                 warn!("{:}", e);
             });
         }
     }
 
-    pub fn set_image(&mut self, img: &[Spectrum]) {
+    pub fn set_image(&self, img: &[Spectrum]) {
         let mut pixels = self.pixels.lock().unwrap();
         let n_pixels = self.cropped_pixel_bounds.area() as usize;
         if n_pixels <= img.len() {
@@ -359,7 +364,7 @@ impl Film {
         }
     }
 
-    pub fn add_splat(&mut self, p: &Vector2f, v: &Spectrum) {
+    pub fn add_splat(&self, p: &Vector2f, v: &Spectrum) {
         let _p = ProfilePhase::new(Prof::SplatFilm);
 
         let pi = Point2i::new(p.x.floor() as i32, p.y.floor() as i32);
@@ -407,7 +412,7 @@ impl Film {
         }
     }
 
-    pub fn clear(&mut self) {
+    pub fn clear(&self) {
         let mut pixels = self.pixels.lock().unwrap();
         for index in 0..pixels.len() {
             for i in 0..3 {
@@ -417,19 +422,19 @@ impl Film {
         }
     }
 
-    pub fn render_start(&mut self) {
+    pub fn render_start(&self) {
         let resolution = [
             self.full_resolution[0] as usize,
             self.full_resolution[1] as usize,
         ];
         let channel_names = ["R", "G", "B"];
-        let _ = self
-            .display
-            .start(&self.filename, &resolution, &channel_names);
+        let mut display = self.display.lock().unwrap();
+        let _ = display.start(&self.filename, &resolution, &channel_names);
     }
 
-    pub fn render_end(&mut self) {
-        let _ = self.display.end();
+    pub fn render_end(&self) {
+        let mut display = self.display.lock().unwrap();
+        let _ = display.end();
     }
 
     pub fn write_image(&self) {
@@ -489,8 +494,9 @@ impl Film {
         return offset;
     }
 
-    pub fn add_display(&mut self, display: &Arc<RwLock<dyn Display>>) {
-        self.display.add_display(display);
+    pub fn add_display(&self, display: &Arc<RwLock<dyn Display>>) {
+        let mut displays = self.display.lock().unwrap();
+        displays.add_display(display);
     }
 }
 

--- a/src/core/integrator/sampler.rs
+++ b/src/core/integrator/sampler.rs
@@ -184,7 +184,7 @@ impl SampleIntegratorCore {
     }
 
     pub fn merge_film_tile(film: &Arc<RwLock<Film>>, tile: &FilmTile) {
-        let mut film = film.write().unwrap();
+        let film = film.read().unwrap();
         film.merge_film_tile(tile);
         film.update_display(&tile.get_pixel_bounds());
     }
@@ -265,7 +265,7 @@ impl SampleIntegratorCore {
     ) {
         let mut tile_indices = Vec::new();
         {
-            let mut film = film.as_ref().write().unwrap();
+            let film = film.as_ref().read().unwrap();
             let sample_bounds = film.get_sample_bounds();
             let sample_extent = sample_bounds.diagonal();
             const TILE_SIZE: i32 = 16;
@@ -318,7 +318,7 @@ impl SampleIntegratorCore {
         }
 
         {
-            let mut film = film.as_ref().write().unwrap();
+            let film = film.as_ref().read().unwrap();
             film.render_end();
             film.write_image();
         }

--- a/src/integrators/bdpt.rs
+++ b/src/integrators/bdpt.rs
@@ -121,7 +121,7 @@ impl Integrator for BDPTIntegrator {
         {
             let camera = self.camera.as_ref();
             let film = camera.get_film();
-            let mut film = film.write().unwrap();
+            let film = film.read().unwrap();
             film.render_start();
         }
 
@@ -298,17 +298,17 @@ impl Integrator for BDPTIntegrator {
                                                     } else {
                                                         l_path
                                                     };
-                                                    let mut film = weight_films
+                                                    let film = weight_films
                                                         .get(&(s, t))
                                                         .unwrap()
-                                                        .write()
+                                                        .read()
                                                         .unwrap();
                                                     film.add_splat(&p_film_new, &value);
                                                 }
                                                 if t != 1 {
                                                     l += l_path;
                                                 } else {
-                                                    let mut f = film.write().unwrap();
+                                                    let f = film.read().unwrap();
                                                     f.add_splat(&p_film_new, &l_path);
                                                 }
                                             }
@@ -326,7 +326,7 @@ impl Integrator for BDPTIntegrator {
                         }
 
                         {
-                            let mut f = film.write().unwrap();
+                            let f = film.read().unwrap();
                             f.merge_film_tile(&film_tile);
                             f.update_display(&film_tile.pixel_bounds);
                         }
@@ -334,7 +334,7 @@ impl Integrator for BDPTIntegrator {
                             let mut prev_time = prev_time.lock().unwrap();
                             let elapsed = prev_time.elapsed();
                             if elapsed.as_millis() > UPDATE_DISPLAY_INTERVAL {
-                                let mut f = film.write().unwrap();
+                                let f = film.read().unwrap();
                                 f.merge_splats(1.0 / samples_per_pixel as Float);
                                 f.update_display(&cropped_pixel_bounds);
                                 *prev_time = Instant::now();
@@ -351,7 +351,7 @@ impl Integrator for BDPTIntegrator {
         {
             let camera = self.camera.as_ref();
             let film = camera.get_film();
-            let mut film = film.as_ref().write().unwrap();
+            let film = film.as_ref().read().unwrap();
             film.merge_splats(1.0 / samples_per_pixel as Float);
             film.update_display(&cropped_pixel_bounds);
             film.render_end();
@@ -360,7 +360,7 @@ impl Integrator for BDPTIntegrator {
 
         if visualize_info {
             for film in weight_films.values() {
-                let mut film = film.write().unwrap();
+                let film = film.read().unwrap();
                 film.merge_splats(1.0);
                 film.write_image();
             }

--- a/src/integrators/mlt.rs
+++ b/src/integrators/mlt.rs
@@ -7,7 +7,7 @@ use std::sync::Mutex;
 use std::sync::RwLock;
 use std::time::Instant;
 
-use rayon::iter::*;
+use rayon::prelude::*;
 
 // MLTSampler Constants
 const CAMERA_STREAM_INDEX: u64 = 0;
@@ -17,6 +17,7 @@ const N_SAMPLE_STREAMS: u64 = 3;
 
 // MLT Constants
 const PROGRESS_FREQUENCY: u32 = 32768;
+const BOOTSTRAP_PROGRESS_FREQUENCY: usize = 256;
 const UPDATE_DISPLAY_INTERVAL: u128 = 1000;
 
 #[derive(Debug, PartialEq, Default, Clone)]
@@ -352,7 +353,7 @@ impl Integrator for MLTIntegrator {
         {
             let camera = self.camera.clone();
             let film = camera.get_film();
-            let mut film = film.write().unwrap();
+            let film = film.read().unwrap();
             film.render_start();
         }
 
@@ -376,7 +377,7 @@ impl Integrator for MLTIntegrator {
         let max_depth = self.max_depth as u32;
         let n_bootstrap_samples = n_bootstrap * (max_depth + 1);
 
-        let bootstrap_weights = Mutex::new(vec![0.0; n_bootstrap_samples as usize]);
+        let mut bootstrap_weights = vec![0.0; n_bootstrap_samples as usize];
         if scene.lights.len() > 0 {
             let reporter = Arc::new(RwLock::new(ProgressReporter::new(
                 n_bootstrap as usize,
@@ -386,52 +387,54 @@ impl Integrator for MLTIntegrator {
             let sigma = self.sigma;
             let large_step_probability = self.large_step_probability;
             let n_sample_streams = N_SAMPLE_STREAMS;
-            (0..n_bootstrap).into_par_iter().for_each(|i| {
-                // Generate _i_th bootstrap sample
-                let mut arena = MemoryArena::new();
-                let mut camera_vertices = Vec::with_capacity(max_depth as usize + 2);
-                let mut light_vertices = Vec::with_capacity(max_depth as usize + 1);
+            bootstrap_weights
+                .par_chunks_mut((max_depth + 1) as usize)
+                .enumerate()
+                .for_each(|(i, weights)| {
+                    // Generate _i_th bootstrap sample
+                    let mut arena = MemoryArena::new();
+                    let mut camera_vertices = Vec::with_capacity(max_depth as usize + 2);
+                    let mut light_vertices = Vec::with_capacity(max_depth as usize + 1);
 
-                for depth in 0..=max_depth {
-                    let rng_index = i * (max_depth + 1) + depth;
-                    let mut sampler = MLTSampler::new(
-                        mutations_per_pixel,
-                        rng_index as u64,
-                        sigma,
-                        large_step_probability,
-                        n_sample_streams,
-                    );
-                    let (l, _p_raster) = self.l(
-                        scene,
-                        &mut arena,
-                        &light_distr,
-                        &light_to_index,
-                        &mut sampler,
-                        &mut camera_vertices,
-                        &mut light_vertices,
-                        depth,
-                    );
-                    let y = l.y();
-                    if y > 0.0 {
-                        let mut bootstrap_weights = bootstrap_weights.lock().unwrap();
-                        bootstrap_weights[rng_index as usize] = y;
+                    for depth in 0..=max_depth {
+                        let rng_index = (i as u32) * (max_depth + 1) + depth;
+                        let mut sampler = MLTSampler::new(
+                            mutations_per_pixel,
+                            rng_index as u64,
+                            sigma,
+                            large_step_probability,
+                            n_sample_streams,
+                        );
+                        let (l, _p_raster) = self.l(
+                            scene,
+                            &mut arena,
+                            &light_distr,
+                            &light_to_index,
+                            &mut sampler,
+                            &mut camera_vertices,
+                            &mut light_vertices,
+                            depth,
+                        );
+                        weights[depth as usize] = l.y();
+                        arena.reset();
                     }
-                }
-                {
-                    let mut reporter = reporter.write().unwrap();
-                    reporter.update(1);
-                }
-            });
+                    if (i + 1) % BOOTSTRAP_PROGRESS_FREQUENCY == 0 {
+                        let mut reporter = reporter.write().unwrap();
+                        reporter.update(BOOTSTRAP_PROGRESS_FREQUENCY);
+                    }
+                });
+            let remainder = (n_bootstrap as usize) % BOOTSTRAP_PROGRESS_FREQUENCY;
+            if remainder != 0 {
+                let mut reporter = reporter.write().unwrap();
+                reporter.update(remainder);
+            }
             {
                 let mut reporter = reporter.write().unwrap();
                 reporter.done();
             }
         }
 
-        let bootstrap = {
-            let bootstrap_weights = bootstrap_weights.lock().unwrap();
-            Distribution1D::new(&bootstrap_weights)
-        };
+        let bootstrap = Distribution1D::new(&bootstrap_weights);
         let b = bootstrap.func_int * (max_depth + 1) as Float;
         let splat_scale = b as Float / mutations_per_pixel as Float;
         //println!("b: {}, {}", bootstrap.func_int, max_depth);
@@ -540,7 +543,7 @@ impl Integrator for MLTIntegrator {
 
                     // Splat both current and proposed samples to _film_
                     {
-                        let mut film = film.write().unwrap();
+                        let film = film.read().unwrap();
                         if accept > 0.0 {
                             let spec = l_proposed * (accept / l_proposed.y());
                             film.add_splat(&p_proposed, &spec);
@@ -560,18 +563,16 @@ impl Integrator for MLTIntegrator {
                     }
                     //totalMutations++;
 
-                    {
-                        let mut reporter = reporter.write().unwrap();
-                        reporter.update(1);
-                    }
-
-                    let iteration = count_iteration.fetch_add(1, Ordering::Acquire);
-                    {
-                        if (iteration % progress_frequency) == 0 {
-                            let mut prev_time = prev_time.lock().unwrap();
-                            let elapsed = prev_time.elapsed();
-                            if elapsed.as_millis() > UPDATE_DISPLAY_INTERVAL {
-                                let mut film = film.write().unwrap();
+                    let iteration = count_iteration.fetch_add(1, Ordering::Relaxed) + 1;
+                    if (iteration % progress_frequency) == 0 {
+                        {
+                            let mut reporter = reporter.write().unwrap();
+                            reporter.update(progress_frequency);
+                        }
+                        let mut prev_time = prev_time.lock().unwrap();
+                        let elapsed = prev_time.elapsed();
+                        if elapsed.as_millis() > UPDATE_DISPLAY_INTERVAL {
+                            if let Ok(film) = film.try_read() {
                                 film.merge_splats(splat_scale);
                                 let display_scale =
                                     n_total_iterations as Float / iteration as Float;
@@ -580,15 +581,15 @@ impl Integrator for MLTIntegrator {
                             }
                         }
                     }
+                    arena.reset();
                 }
-                arena.reset();
             });
 
             // Store final image computed with MLT
             {
                 let camera = self.camera.clone();
                 let film = camera.get_film();
-                let mut film = film.write().unwrap();
+                let film = film.read().unwrap();
                 film.merge_splats(splat_scale);
                 film.update_display(&pixel_bounds);
                 film.render_end();
@@ -596,7 +597,12 @@ impl Integrator for MLTIntegrator {
             }
 
             {
+                let completed_iterations = count_iteration.load(Ordering::Relaxed);
+                let remainder = completed_iterations % progress_frequency;
                 let mut reporter = reporter.write().unwrap();
+                if remainder != 0 {
+                    reporter.update(remainder);
+                }
                 reporter.done();
             }
         }

--- a/src/integrators/sppm.rs
+++ b/src/integrators/sppm.rs
@@ -154,7 +154,7 @@ impl Integrator for SPPMIntegrator {
         let setup_film_t0 = Instant::now();
         {
             let film = self.get_film();
-            let mut film = film.write().unwrap();
+            let film = film.read().unwrap();
             film.render_start();
         }
         t_setup_film += setup_film_t0.elapsed().as_secs_f64();
@@ -838,7 +838,7 @@ impl Integrator for SPPMIntegrator {
                     }
                     {
                         let film = self.get_film();
-                        let mut film = film.write().unwrap();
+                        let film = film.read().unwrap();
                         film.set_image(&image);
                         if write_image {
                             film.write_image();
@@ -867,7 +867,7 @@ impl Integrator for SPPMIntegrator {
         let finalize_t0 = Instant::now();
         {
             let film = self.get_film();
-            let mut film = film.write().unwrap();
+            let film = film.read().unwrap();
             film.render_end();
             film.write_image();
         }


### PR DESCRIPTION
This pull request introduces significant thread-safety improvements and code refactoring to the film and display handling logic, as well as some optimizations and bug fixes in the BVH building and MLT integrator. The primary focus is on making the `Film` and related display operations safe for concurrent access by using `Mutex` and changing method signatures to accept shared references. Additional changes include fallback logic for BVH splitting and parallelization improvements in the MLT integrator.

**Thread-safety and API refactoring for `Film` and display handling:**

- Refactored the `Film` struct to wrap its `MutipleDisplay` member in a `Mutex`, and updated all public methods to take `&self` instead of `&mut self`, allowing safe concurrent access from multiple threads. Methods that modify display state now lock the mutex internally. (`src/core/film/film.rs`, `src/core/display/display.rs`, `src/bin/pbrt.rs`, `src/core/integrator/sampler.rs`, `src/integrators/bdpt.rs`) [[1]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L49-R49) [[2]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L153-R153) [[3]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L219-R219) [[4]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L243-R243) [[5]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L278-R287) [[6]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L344-R355) [[7]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L362-R367) [[8]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L410-R415) [[9]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L420-R437) [[10]](diffhunk://#diff-5911487cc556239704b1e635265c81aa06c29d6a79c194d207c69f75170dbc18L492-R499) [[11]](diffhunk://#diff-07bfe62344d7feb9ad7cd8aae29c7582a013af88286ed2deb769778df55e6d0dL11-R11) [[12]](diffhunk://#diff-cfb17a1e97f15859b685d371717181ec59ef001cd078a89c24e234adc386d42aL303-R303) [[13]](diffhunk://#diff-cfb17a1e97f15859b685d371717181ec59ef001cd078a89c24e234adc386d42aL319-R319) [[14]](diffhunk://#diff-84028a0d3be0fe4f42cdc3646a5fdd502fb130737de04378bb7c5c6c27f92423L187-R187) [[15]](diffhunk://#diff-84028a0d3be0fe4f42cdc3646a5fdd502fb130737de04378bb7c5c6c27f92423L268-R268) [[16]](diffhunk://#diff-84028a0d3be0fe4f42cdc3646a5fdd502fb130737de04378bb7c5c6c27f92423L321-R321) [[17]](diffhunk://#diff-c292a8ccbe7ea1bb8a0900a6e04818bc179e4043f705da132b61b54e43138898L124-R124) [[18]](diffhunk://#diff-c292a8ccbe7ea1bb8a0900a6e04818bc179e4043f705da132b61b54e43138898L301-R311) [[19]](diffhunk://#diff-c292a8ccbe7ea1bb8a0900a6e04818bc179e4043f705da132b61b54e43138898L329-R337) [[20]](diffhunk://#diff-c292a8ccbe7ea1bb8a0900a6e04818bc179e4043f705da132b61b54e43138898L354-R354) [[21]](diffhunk://#diff-c292a8ccbe7ea1bb8a0900a6e04818bc179e4043f705da132b61b54e43138898L363-R363) [[22]](diffhunk://#diff-5ec30625b441331251d0cdb029afde4b5dd5ebb1f4da1235c9265c25513c0fc9L355-R356)

**BVH building and splitting improvements:**

- Added a fallback to `split_equal_counts` in the SAH split logic if either side of the split is empty, improving robustness for degenerate cases. (`src/accelerators/bvh/build/sah.rs`)
- Minor logic fixes and cleanup in BVH node recursive build for split methods. (`src/accelerators/bvh/build/node.rs`) [[1]](diffhunk://#diff-7088c29fadd70cf01fd749914b65e5089fb0b758c2debd5cd307283c34a503e6L56-R65) [[2]](diffhunk://#diff-7088c29fadd70cf01fd749914b65e5089fb0b758c2debd5cd307283c34a503e6L76)
- Added missing import for `equal_counts` in SAH splitting. (`src/accelerators/bvh/build/sah.rs`)

**MLT integrator improvements:**

- Changed from using a `Mutex`-protected vector to a plain vector for `bootstrap_weights`, and parallelized the initialization using `par_chunks_mut` for better performance. (`src/integrators/mlt.rs`) [[1]](diffhunk://#diff-5ec30625b441331251d0cdb029afde4b5dd5ebb1f4da1235c9265c25513c0fc9R20) [[2]](diffhunk://#diff-5ec30625b441331251d0cdb029afde4b5dd5ebb1f4da1235c9265c25513c0fc9L379-R380) [[3]](diffhunk://#diff-5ec30625b441331251d0cdb029afde4b5dd5ebb1f4da1235c9265c25513c0fc9L389-R400)
- Switched from `rayon::iter::*` to `rayon::prelude::*` for improved parallel iteration ergonomics. (`src/integrators/mlt.rs`)

**Version update:**

- Bumped crate version from `3.1.8` to `3.2.0` in `Cargo.toml`.