### PR TITLE
Release version 3.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pbrt-r3"
-version = "3.1.9"
+version = "3.2.0"
 edition = "2021"
 build = "build/main.rs"
 default-run = "pbrt-r3"


### PR DESCRIPTION
This pull request updates the version number of the `pbrt-r3` package in the `Cargo.toml` file from `3.1.9` to `3.2.0`.